### PR TITLE
Bump default node count and instance types

### DIFF
--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -22,15 +22,15 @@ bastion:
   image: "https://www.googleapis.com/compute/v1/projects/capi-test-phoenix/global/images/cluster-api-ubuntu-1804-v1-20-10-1642604275"
 
 controlPlane:
-  instanceType: n1-standard-2
-  replicas: 1  # Should be an odd number.
+  instanceType: n2-standard-4
+  replicas: 3  # Should be an odd number.
   rootVolumeSizeGB: 120
 
 machineDeployments:
 - name: def00
   failureDomain: europe-west6-a
-  instanceType: n1-standard-2
-  replicas: 3
+  instanceType: n2-standard-4
+  replicas: 4
   rootVolumeSizeGB: 300
   customNodeLabels:
   - label=default


### PR DESCRIPTION
* Move from `n1-standard-2` with 2 vCPU and 7Gbi to `n2-standard-4` with 4 vCPU and 16Gbi. Otherwise there is not enough CPU for everything deployed on an MC
* Bump control-plane nodes to 3 and worker nodes to 4, to be more alinged with AWS and Azure MCs