### PR TITLE
Add team label to helm resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add team label to helm resources.
+
 ## [0.5.0] - 2022-04-28
 
 - Move default instance type from n1-standard-2 with 2 vCPU and 7Gbi to n2-standard-4 with 4 vCPU and 16Gbi

--- a/helm/cluster-gcp/templates/_helpers.tpl
+++ b/helm/cluster-gcp/templates/_helpers.tpl
@@ -25,6 +25,7 @@ cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
CI was complaining because of missing team label, so let's add it https://app.circleci.com/pipelines/github/giantswarm/cluster-gcp/99/workflows/03e0ce1d-9673-4cb5-9f8d-05dec31d3054/jobs/99