### PR TITLE
Fix machine deployments range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix helm not generating all KubeadmConfigTemplate's for each machine deployment
+
 ## [0.5.0] - 2022-04-28
 
 - Move default instance type from n1-standard-2 with 2 vCPU and 7Gbi to n2-standard-4 with 4 vCPU and 16Gbi

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -72,5 +72,6 @@ spec:
       {{- include "sshPostKubeadmCommands" . | nindent 6 }}
       users:
       {{- include "sshUsers" . | nindent 6 }}
+---
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
The document separator at the end of the KubeadmConfigTemplate is needed, otherwise helm 
generates only a single KubeadmConfigTemplate with the last machineDeployment's name.