### PR TITLE
Add ServiceAccount to control-plane MachineTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add team label to helm resources.
 - Add `values.schema.json` file.
+- Add Service Account to control-plane MachineTemplate
 
 ## [0.5.1] - 2022-04-28
 

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -102,4 +102,6 @@ spec:
       image: {{ .Values.gcp.baseImage }}
       instanceType: {{ .Values.controlPlane.instanceType }}
       rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
+      serviceAccounts:
+        email: {{ .Values.controlPlane.serviceAccount.email }}
 {{- end -}}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -33,6 +33,14 @@
                 },
                 "rootVolumeSizeGB": {
                     "type": "integer"
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "email": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -25,6 +25,8 @@ controlPlane:
   instanceType: n2-standard-4
   replicas: 3  # Should be an odd number.
   rootVolumeSizeGB: 120
+  serviceAccount:
+    email: "service-account@email"  # A service account used by the control-plane to set up LoadBalancer Services
 
 machineDeployments:
 - name: def00


### PR DESCRIPTION
Currently, by default, the Compute Engine default service account is assigned to all the VM instances (looks something like `<project-id-number>-compute@developer.gserviceaccount.com `. That one might not have any permissions though. The `service-controller` on the control plane uses this service account to create LoadBalancer ServiceAccounts (the kubernetes kind this time).

This change makes it so that we can specify the service account (the gcp kind) on the control plane nodes and control what permissions it has.