### PR TITLE
Add the compute-rw scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Set the `scopes` (`compute-rw` by default) on control-plane's MachineTemplate Service Account
+
 ## [0.6.0] - 2022-05-12
 
 ### Changed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -104,4 +104,5 @@ spec:
       rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
       serviceAccounts:
         email: {{ .Values.controlPlane.serviceAccount.email }}
+        scopes: {{ .Values.controlPlane.serviceAccount.scopes }}
 {{- end -}}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -39,6 +39,12 @@
                     "properties": {
                         "email": {
                             "type": "string"
+                        },
+                        "scopes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -27,6 +27,8 @@ controlPlane:
   rootVolumeSizeGB: 120
   serviceAccount:
     email: "service-account@email"  # A service account used by the control-plane to set up LoadBalancer Services
+    scopes:
+    - "https://www.googleapis.com/auth/compute"
 
 machineDeployments:
 - name: def00


### PR DESCRIPTION
By default the instance will receive no scopes, which means it won't be
able to do anything.
We only need the Compute scope.
See [gcloud docs --scopes flag](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create) for list of scopes