### PR TITLE
add-cloud-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `cloud-config` for GCP cloud provider to enable multizone for controller manager.
+
 ## [0.6.1] - 2022-05-13
 
 - Set the `scopes` (`compute-rw` by default) on control-plane's MachineTemplate Service Account

--- a/helm/cluster-gcp/files/etc/kubernetes/gcp.conf
+++ b/helm/cluster-gcp/files/etc/kubernetes/gcp.conf
@@ -1,0 +1,2 @@
+[global]
+multizone = true

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -50,6 +50,12 @@ spec:
           allocate-node-cidrs: "false"
           bind-address: 0.0.0.0
           cloud-provider: gce
+          cloud-config: /etc/kubernetes/gcp.conf
+        extraVolumes:
+        - hostPath: /etc/kubernetes/gcp.conf
+          mountPath: /etc/kubernetes/gcp.conf
+          name: cloud-config
+          readOnly: true
       scheduler:
         extraArgs:
           bind-address: 0.0.0.0

--- a/helm/cluster-gcp/templates/_helpers.tpl
+++ b/helm/cluster-gcp/templates/_helpers.tpl
@@ -61,6 +61,10 @@ room for such suffix.
   permissions: "0600"
   encoding: base64
   content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
+- path: /etc/kubernetes/gcp.conf
+  permissions: "0600"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/kubernetes/gcp.conf" | b64enc }}
 {{- end -}}
 
 


### PR DESCRIPTION

- Add `cloud-config` for GCP cloud provider to enable multizone for controller manager.
