### PR TITLE
Render failure domains as an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Render failure domains on the `GCPCluster` as an array.
+- Use same service account default than CAPG.
 
 ## [0.8.0] - 2022-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Render failure domains on the `GCPCluster` as an array.
+
 ## [0.8.0] - 2022-05-30
 
 ### Added

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -12,5 +12,8 @@ spec:
     autoCreateSubnetworks: {{ .Values.network.autoCreateSubnetworks }}
   region: {{ .Values.gcp.region }}
   project: {{ .Values.gcp.project }}
-  failureDomains: {{ .Values.gcp.failureDomains }}
+  failureDomains: |-
+    {{- range .Values.gcp.failureDomains }}
+    - {{ . }}
+    {{- end }}
 {{ end }}

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -12,7 +12,7 @@ spec:
     autoCreateSubnetworks: {{ .Values.network.autoCreateSubnetworks }}
   region: {{ .Values.gcp.region }}
   project: {{ .Values.gcp.project }}
-  failureDomains: |-
+  failureDomains:
     {{- range .Values.gcp.failureDomains }}
     - {{ . }}
     {{- end }}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -157,13 +157,7 @@
                 "usernameClaim": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "clientId",
-                "groupsClaim",
-                "issuerUrl",
-                "usernameClaim"
-            ]
+            }
         },
         "organization": {
             "type": "string"

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -9,7 +9,7 @@ gcp:
   region: "europe-west3"
   project: "capi-test-phoenix"
   failureDomains:
-  - "europe-west3-a"
+    - europe-west3-a
 
 network:
   autoCreateSubnetworks: true
@@ -27,7 +27,7 @@ controlPlane:
   replicas: 3  # Should be an odd number.
   rootVolumeSizeGB: 120
   serviceAccount:
-    email: "service-account@email"  # A service account used by the control-plane to set up LoadBalancer Services
+    email: "default"  # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
     - "https://www.googleapis.com/auth/compute"
 


### PR DESCRIPTION
When passing several failure domains, these get rendered on the `App` as
```
failureDomains: [europe-west3-a europe-west3-b]
```

which gets rendered in the `GCPCluster` as 

```
spec:
  controlPlaneEndpoint:
    host: ""
    port: 0
  failureDomains:
  - europe-west3-a europe-west3-b europe-west3-c
```

This is a single value `europe-west3-a europe-west3-b europe-west3-c` instead of an array.