### PR TITLE
Prevent setting failureDomain not in region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent setting a failureDomain not in the specified region
+
 ## [0.10.0] - 2022-06-06
 
 - Add bastion support.

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -14,6 +14,10 @@ spec:
   project: {{ .Values.gcp.project }}
   failureDomains:
     {{- range .Values.gcp.failureDomains }}
+    {{- if (hasPrefix $.Values.gcp.region .) }}
     - {{ . }}
+    {{- else -}}
+    {{ fail (printf "Failure domain '%s' must be part of the provided region '%s'" . $.Values.gcp.region )}}
+    {{- end -}}
     {{- end }}
 {{ end }}

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -24,7 +24,11 @@ spec:
           kind: KubeadmConfigTemplate
           name: {{ include "resource.default.name" $ }}-{{ .name }}
       clusterName: {{ include "resource.default.name" $ }}
+      {{- if (hasPrefix $.Values.gcp.region .failureDomain) }}
       failureDomain: {{ .failureDomain }}
+      {{- else -}}
+      {{ fail (printf "Failure domain '%s' must be part of the provided region '%s'" .failureDomain $.Values.gcp.region )}}
+      {{- end }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPMachineTemplate


### PR DESCRIPTION
To avoid issues with the `zone` being wrong we should block the chart from rending with incorrect values provided.