### PR TITLE
Support custom subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support specifying custom subnets
+
+### Fixed
+
+- Makefile task to generate values schema
+
 ## [0.13.0] - 2022-06-23
 
 ### Added

--- a/Makefile.gen.app.mk
+++ b/Makefile.gen.app.mk
@@ -18,7 +18,7 @@ lint-chart: ## Runs ct against the default chart.
 
 
 ensure-schema-gen:
-	@helm schema-gen &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
+	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
 
 .PHONY: schema-gen
 schema-gen: ensure-schema-gen ## Generates the values schema file

--- a/helm/cluster-gcp/templates/_bastion.tpl
+++ b/helm/cluster-gcp/templates/_bastion.tpl
@@ -53,6 +53,9 @@ spec:
       additionalNetworkTags:
       - {{ include "resource.default.name" $ }}-bastion
       image: {{ include "vmImage" $ }}
+      {{- if .Values.bastion.subnet }}
+      subnet: {{ .Values.bastion.subnet }}
+      {{- end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -121,6 +121,9 @@ spec:
       image: {{ include "vmImage" $ }}
       instanceType: {{ .Values.controlPlane.instanceType }}
       rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
+      {{- if .Values.controlPlane.subnet }}
+      subnet: {{ .Values.controlPlane.subnet }}
+      {{- end}}
       serviceAccounts:
         email: {{ .Values.controlPlane.serviceAccount.email }}
         scopes: {{ .Values.controlPlane.serviceAccount.scopes }}

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -10,6 +10,13 @@ spec:
   network:
     name: {{ include "resource.default.name" $ }}-network
     autoCreateSubnetworks: {{ .Values.network.autoCreateSubnetworks }}
+    {{- if eq .Values.network.autoCreateSubnetworks false }}
+    subnets:
+    {{- range .Values.network.nodeSubnetCidrs }}
+    - cidrBlock: {{ . }}
+      region: {{ $.Values.gcp.region }}
+    {{- end }}
+    {{- end }}
   region: {{ .Values.gcp.region }}
   project: {{ .Values.gcp.project }}
   failureDomains:

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -49,6 +49,9 @@ spec:
       image: {{ include "vmImage" $global }}
       instanceType: {{ .instanceType }}
       rootDeviceSize: {{ .rootVolumeSizeGB }}
+      {{- if .subnet }}
+      subnet: {{ .subnet }}
+      {{- end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -69,7 +72,7 @@ spec:
             healthz-bind-address: 0.0.0.0
             image-pull-progress-deadline: 1m
             node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
-            node-labels: role=worker,giantswarm.io/machine-deployment={{ .name }},{{- join "," .customNodeLabels }}
+            node-labels: role=worker,giantswarm.io/machine-deployment={{ .name }}{{ if .customNodeLabels }},{{- join "," .customNodeLabels }}{{ end }}
             v: "2"
           name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
       postKubeadmCommands:

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -96,10 +96,7 @@
                 "type": "object",
                 "properties": {
                     "customNodeLabels": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "array"
                     },
                     "failureDomain": {
                         "type": "string"
@@ -124,6 +121,9 @@
             "properties": {
                 "autoCreateSubnetworks": {
                     "type": "boolean"
+                },
+                "nodeSubnetCidrs": {
+                    "type": "array"
                 },
                 "podCidr": {
                     "type": "array",

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -17,7 +17,7 @@ gcp:
 
 network:
   autoCreateSubnetworks: true
-  nodeSubnetCidrs: [] # Array of CIDRs to be used if `autoCreateSubnetworks` is set to `false`
+  nodeSubnetCidrs: []  # Array of CIDRs to be used if `autoCreateSubnetworks` is set to `false`
   podCidr:
     - "192.168.0.0/16"
   serviceCIDR: 172.31.0.0/16

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -12,9 +12,12 @@ gcp:
   project: "capi-test-phoenix"
   failureDomains:
     - europe-west3-a
+    - europe-west3-b
+    - europe-west3-c
 
 network:
   autoCreateSubnetworks: true
+  nodeSubnetCidrs: [] # Array of CIDRs to be used if `autoCreateSubnetworks` is set to `false`
   podCidr:
     - "192.168.0.0/16"
   serviceCIDR: 172.31.0.0/16
@@ -23,11 +26,13 @@ bastion:
   enabled: true
   instanceType: n1-standard-2
   replicas: 1
+  # subnet:
 
 controlPlane:
   instanceType: n2-standard-4
   replicas: 3  # Should be an odd number.
   rootVolumeSizeGB: 120
+  # subnet:
   serviceAccount:
     email: "default"  # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
@@ -39,31 +44,24 @@ machineDeployments:
   instanceType: n2-standard-4
   replicas: 1
   rootVolumeSizeGB: 300
-  customNodeLabels:
-  - label=default
+  customNodeLabels: []
+  # subnet:
 - name: def01
   failureDomain: europe-west3-b
   instanceType: n2-standard-4
   replicas: 1
   rootVolumeSizeGB: 300
-  customNodeLabels:
-  - label=default
+  customNodeLabels: []
+  # subnet:
 - name: def02
   failureDomain: europe-west3-c
   instanceType: n2-standard-4
   replicas: 1
   rootVolumeSizeGB: 300
-  customNodeLabels:
-  - label=default
+  customNodeLabels: []
+  # subnet:
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-
-# Used by `cluster-shared` library chart
-includeClusterResourceSet: true
-kubectlImage:
-  registry: quay.io
-  name: giantswarm/kubectl
-  tag: 1.23.5
 
 oidc:
   issuerUrl: ""
@@ -71,3 +69,10 @@ oidc:
   clientId: ""
   usernameClaim: ""
   groupsClaim: ""
+
+# Used by `cluster-shared` library chart
+includeClusterResourceSet: true
+kubectlImage:
+  registry: quay.io
+  name: giantswarm/kubectl
+  tag: 1.23.5


### PR DESCRIPTION
Allows for custom subnets to be provided instead of the auto-generated. Also adds the ability to specify the subnet that machinedeployments are put into.

Fixes https://github.com/giantswarm/roadmap/issues/1144 

Chores:
* Fixed gen-schema make task.
* Removed `label=default` example machine label (and updated template to make it optional without a trailing `,`)