### PR TITLE
add-disk-for-control-plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add additional disks for control plane nodes.
+- Add additional disks for worke nodes.
+
 ### Fixed
 
 - Bump cluster-shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add additional disks for control plane nodes.
-- Add additional disks for worke nodes.
+- Add additional disks for worker nodes.
 
 ## [0.14.2] - 2022-06-29
 

--- a/helm/cluster-gcp/files/opt/init-disks.sh
+++ b/helm/cluster-gcp/files/opt/init-disks.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+CONTAINERD_DISK="/dev/sdb"
+KUBELET_DISK="/dev/sdc"
+ETCD_DISK="/dev/sdd"
+
+# init kubelet disk
+mkfs.xfs $KUBELET_DISK
+mkdir -p /var/lib/kubelet
+mount $KUBELET_DISK /var/lib/kubelet
+
+# init containerd disk
+mkfs.xfs $CONTAINERD_DISK
+systemctl stop containerd
+rm -rf /var/lib/containerd
+mkdir -p /var/lib/containerd
+mount $CONTAINERD_DISK /var/lib/containerd
+systemctl start containerd
+
+if [ -e "${ETCD_DISK}" ]; then
+        # init etcd disk
+        mkfs.xfs $ETCD_DISK
+        mkdir -p /var/lib/etcd
+        mount $ETCD_DISK /var/lib/etcd
+fi

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -121,6 +121,13 @@ spec:
       image: {{ include "vmImage" $ }}
       instanceType: {{ .Values.controlPlane.instanceType }}
       rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
+      additionalDisks:
+      - deviceType: pd-ssd
+        size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
+      - deviceType: pd-ssd
+        size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
+      - deviceType: pd-ssd
+        size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
       {{- if .Values.controlPlane.subnet }}
       subnet: {{ .Values.controlPlane.subnet }}
       {{- end}}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -100,6 +100,8 @@ spec:
         kubeletExtraArgs:
           cloud-provider: gce
         name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
+    preKubeadmCommands:
+    - /bin/bash /opt/init-disks.sh
     postKubeadmCommands:
     {{- include "sshPostKubeadmCommands" . | nindent 4 }}
     users:

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -50,6 +50,11 @@ spec:
       image: {{ include "vmImage" $global }}
       instanceType: {{ .instanceType }}
       rootDeviceSize: {{ .rootVolumeSizeGB }}
+      additionalDisks:
+      - deviceType: pd-ssd
+        size: {{ .containerdVolumeSizeGB }}
+      - deviceType: pd-ssd
+        size: {{ .kubeletVolumeSizeGB }}
       {{- if .subnet }}
       subnet: {{ .subnet }}
       {{- end }}
@@ -76,6 +81,11 @@ spec:
             node-labels: role=worker,giantswarm.io/machine-deployment={{ .name }}{{ if .customNodeLabels }},{{- join "," .customNodeLabels }}{{ end }}
             v: "2"
           name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
+      files:
+      {{- include "sshFiles" . | nindent 6 }}
+      {{- include "diskFiles" . | nindent 6 }}
+      preKubeadmCommands:
+      - /bin/bash /opt/init-disks.sh
       postKubeadmCommands:
       {{- include "sshPostKubeadmCommands" . | nindent 6 }}
       users:

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -82,8 +82,8 @@ spec:
             v: "2"
           name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
       files:
-      {{- include "sshFiles" . | nindent 6 }}
-      {{- include "diskFiles" . | nindent 6 }}
+      {{- include "sshFiles" $ | nindent 6 }}
+      {{- include "diskFiles" $ | nindent 6 }}
       preKubeadmCommands:
       - /bin/bash /opt/init-disks.sh
       postKubeadmCommands:

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -121,6 +121,12 @@
                     },
                     "rootVolumeSizeGB": {
                         "type": "integer"
+                    },
+                    "containerdVolumeSizeGB": {
+                        "type": "integer"
+                    },
+		    "kubeletVolumeSizeGB": {
+                        "type": "integer"
                     }
                 }
             }

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -37,6 +37,15 @@
                 "rootVolumeSizeGB": {
                     "type": "integer"
                 },
+		"etcdVolumeSizeGB": {
+                    "type": "integer"
+                },
+		"containerdVolumeSizeGB": {
+                    "type": "integer"
+                },
+		"kubeletVolumeSizeGB": {
+                    "type": "integer"
+                },
                 "serviceAccount": {
                     "type": "object",
                     "properties": {

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -46,21 +46,27 @@ machineDeployments:
   failureDomain: europe-west3-a
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 300
+  rootVolumeSizeGB: 100
+  containerdVolumeSizeGB: 100
+  kubeletVolumeSizeGB: 100
   customNodeLabels: []
   # subnet:
 - name: def01
   failureDomain: europe-west3-b
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 300
+  rootVolumeSizeGB: 100
+  containerdVolumeSizeGB: 100
+  kubeletVolumeSizeGB: 100
   customNodeLabels: []
   # subnet:
 - name: def02
   failureDomain: europe-west3-c
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 300
+  rootVolumeSizeGB: 100
+  containerdVolumeSizeGB: 100
+  kubeletVolumeSizeGB: 100
   customNodeLabels: []
   # subnet:
 

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -31,7 +31,10 @@ bastion:
 controlPlane:
   instanceType: n2-standard-4
   replicas: 3  # Should be an odd number.
-  rootVolumeSizeGB: 120
+  rootVolumeSizeGB: 100
+  etcdVolumeSizeGB: 100
+  containerdVolumeSizeGB: 100
+  kubeletVolumeSizeGB: 100
   # subnet:
   serviceAccount:
     email: "default"  # A service account used by the control-plane to set up LoadBalancer Services


### PR DESCRIPTION
add additional disks for the control plane nodes ( disk for containerd, kubelet and etcd)
add additional disks for the worker nodes (disk  for contained, kubelet)

to align with vintage and CAPA