### PR TITLE
Add labels to MachineSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add labels to `MachineSets` created by `MachineDeployments`.
+
 ## [0.14.2] - 2022-06-29
 
 ### Fixed

--- a/helm/cluster-gcp/templates/_bastion.tpl
+++ b/helm/cluster-gcp/templates/_bastion.tpl
@@ -21,9 +21,8 @@ spec:
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
         cluster.x-k8s.io/deployment-name: {{ include "resource.default.name" $ }}-bastion
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "labels.selector" $ | nindent 8 }}
     spec:
       bootstrap:
         configRef:

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -18,6 +18,9 @@ spec:
   selector:
     matchLabels: null
   template:
+    metadata:
+      labels:
+        {{- include "labels.selector" $ | nindent 8 }}
     spec:
       bootstrap:
         configRef:


### PR DESCRIPTION
`MachineSets` created by `MachineDeployments` are not labeled with common labels.