### PR TITLE
Allow to set nodepool description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add additional disks for control plane nodes.
 - Add additional disks for worker nodes.
+- Allow to set nodepool description through Helm values.
 
 ## [0.14.2] - 2022-06-29
 

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -5,7 +5,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   annotations:
-    machine-deployment.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ .name }}
+    machine-deployment.giantswarm.io/name: {{ .description | default ( printf "%s-%s" ( include "resource.default.name" $ ) ( .name ) ) | quote }}
   labels:
     giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
     {{- include "labels.common" $ | nindent 4 }}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -28,22 +28,22 @@
         "controlPlane": {
             "type": "object",
             "properties": {
+                "containerdVolumeSizeGB": {
+                    "type": "integer"
+                },
+                "etcdVolumeSizeGB": {
+                    "type": "integer"
+                },
                 "instanceType": {
                     "type": "string"
+                },
+                "kubeletVolumeSizeGB": {
+                    "type": "integer"
                 },
                 "replicas": {
                     "type": "integer"
                 },
                 "rootVolumeSizeGB": {
-                    "type": "integer"
-                },
-		"etcdVolumeSizeGB": {
-                    "type": "integer"
-                },
-		"containerdVolumeSizeGB": {
-                    "type": "integer"
-                },
-		"kubeletVolumeSizeGB": {
                     "type": "integer"
                 },
                 "serviceAccount": {
@@ -104,6 +104,9 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "containerdVolumeSizeGB": {
+                        "type": "integer"
+                    },
                     "customNodeLabels": {
                         "type": "array"
                     },
@@ -113,6 +116,9 @@
                     "instanceType": {
                         "type": "string"
                     },
+                    "kubeletVolumeSizeGB": {
+                        "type": "integer"
+                    },
                     "name": {
                         "type": "string"
                     },
@@ -120,12 +126,6 @@
                         "type": "integer"
                     },
                     "rootVolumeSizeGB": {
-                        "type": "integer"
-                    },
-                    "containerdVolumeSizeGB": {
-                        "type": "integer"
-                    },
-		    "kubeletVolumeSizeGB": {
                         "type": "integer"
                     }
                 }

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -9,8 +9,8 @@ vmImageBase: "https://www.googleapis.com/compute/v1/projects/giantswarm-vm-image
 
 gcp:
   region: "europe-west3"
-  project: "capi-test-phoenix"
-  failureDomains:
+  project: "capi-test-phoenix"  # GCP Project where the cluster will be created.
+  failureDomains:  # These will be the failure domains used for the control plane machines.
     - europe-west3-a
     - europe-west3-b
     - europe-west3-c
@@ -22,6 +22,7 @@ network:
     - "192.168.0.0/16"
   serviceCIDR: 172.31.0.0/16
 
+# A bastion host that will be used for SSH.
 bastion:
   enabled: true
   instanceType: n1-standard-2
@@ -41,8 +42,11 @@ controlPlane:
     scopes:
     - "https://www.googleapis.com/auth/compute"
 
+# machineDeployments lets you configure the different nodepools that will be created.
 machineDeployments:
 - name: def00
+  # The description is the name of the nodepool in GiantSwarm UIs. It's optional.
+  # description:
   failureDomain: europe-west3-a
   instanceType: n2-standard-4
   replicas: 1
@@ -52,6 +56,7 @@ machineDeployments:
   customNodeLabels: []
   # subnet:
 - name: def01
+  # description:
   failureDomain: europe-west3-b
   instanceType: n2-standard-4
   replicas: 1
@@ -61,6 +66,7 @@ machineDeployments:
   customNodeLabels: []
   # subnet:
 - name: def02
+  # description:
   failureDomain: europe-west3-c
   instanceType: n2-standard-4
   replicas: 1


### PR DESCRIPTION
Our UIs (happa, kubectl-gs) will show a description of the nodepool, which is a free text that customers can set as an annotation. We need to allow to set that value.