### PR TITLE
Bump etcd version and make configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped default etcd version to avoid the 3.5.0 issues (See https://github.com/etcd-io/etcd/releases/tag/v3.5.0)
+- Made etcd version configurable via values
+
 ### Fixed
 
 - Moved custom make targets to correct Makefile

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -80,6 +80,7 @@ spec:
           bind-address: 0.0.0.0
       etcd:
         local:
+          imageTag: {{.Values.controlPlane.etcdVersion}}
           extraArgs:
             quota-backend-bytes: "8589934592"
       networking:

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -31,6 +31,9 @@
                 "containerdVolumeSizeGB": {
                     "type": "integer"
                 },
+                "etcdVersion": {
+                    "type": "string"
+                },
                 "etcdVolumeSizeGB": {
                     "type": "integer"
                 },

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -41,6 +41,7 @@ controlPlane:
     email: "default"  # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
     - "https://www.googleapis.com/auth/compute"
+  etcdVersion: 3.5.4-0
 
 # machineDeployments lets you configure the different nodepools that will be created.
 machineDeployments:


### PR DESCRIPTION
etcd 3.5.0 (the current kubeadm default) has a known issue and not recommended for production (see https://github.com/etcd-io/etcd/releases/tag/v3.5.0)

This change bumps the version to the latest available and makes it configurable via helm values.