### PR TITLE
Set routeTableId: false when passing 'nodeSubnetCidrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `routeTableId: false` when passing `nodeSubnetCidrs` as it's mandatory.
+
 ## [0.17.0] - 2022-07-20
 
 ### Added

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -17,6 +17,7 @@ spec:
     {{- range .Values.network.nodeSubnetCidrs }}
     - cidrBlock: {{ . }}
       region: {{ $.Values.gcp.region }}
+      routeTableId: false
     {{- end }}
     {{- end }}
   region: {{ .Values.gcp.region }}


### PR DESCRIPTION
When passing `nodeSubnetCidrs` and `autoCreateSubnetworks: false`  the k8s api complains with

```
The GCPCluster "test-jose" is invalid: spec.network.subnets.routeTableId: Invalid value: "null": spec.network.subnets.routeTableId in body must be of type boolean: "null"
```

This is because [the field is defined as](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/d6458338fb1fa03f87bbc1b6c2e35706c8e5264c/api/v1beta1/types.go#L150)

```
EnableFlowLogs *bool `json:"routeTableId"`
```

so it's a pointer to a boolean. Hence when no set, its value is null. But the openapi schema [defines the field as bool](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/v1.1.1/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml#L581-L586), and in openAPI

> type: boolean represents two values: true and false. Note that truthy and falsy values such as "true", "", 0 or null are not considered boolean values.