### PR TITLE
Expose metrics from components installed by kubeadm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"` to `scheduler` and `controller-manager`
+- Order `kubeadm` extraFlags alphabetically.
+- Set `logtostderr: "true"` to `controller-manager`.
+- Make `etcd` metrics endpoint accessible.
+
 ## [0.18.0] - 2022-07-20
 
 ### Fixed


### PR DESCRIPTION
components deployed by `kubeadm` can't be accessed by prometheus

![image](https://user-images.githubusercontent.com/627038/180025433-c84ab5a7-2c54-4911-af5d-62ea8d80c00d.png)
