### PR TITLE
Set certificates directory to /etc/kubernetes/ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set certificates directory to `/etc/kubernetes/ssl` in KubeadmControlPanel `clusterConfiguration`.
+
 ## [0.20.0] - 2022-07-28
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set certificates directory to `/etc/kubernetes/ssl` in KubeadmControlPanel `clusterConfiguration`.
+- Set certificates directory to `/etc/kubernetes/ssl` in KubeadmControlPanel and KubeadmConfigTemplate `clusterConfiguration`.
+- Set CA certificate path to `/etc/kubernetes/ssl/ca.crt` in KubeadmControlPanel and KubeadmConfigTemplate `joinConfiguration`.
 
 ## [0.20.0] - 2022-07-28
 

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -112,6 +112,7 @@ spec:
         name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
     joinConfiguration:
       discovery: {}
+      caCertPath: /etc/kubernetes/ssl/ca.crt
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: gce

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -92,6 +92,7 @@ spec:
             quota-backend-bytes: "8589934592"
       networking:
         serviceSubnet: {{ .Values.network.serviceCIDR }}
+      certificatesDir: /etc/kubernetes/ssl
     files:
     {{- include "sshFiles" . | nindent 4 }}
     {{- include "diskFiles" . | nindent 4 }}

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -77,6 +77,7 @@ spec:
         certificatesDir: /etc/kubernetes/ssl
       joinConfiguration:
         discovery: {}
+        caCertPath: /etc/kubernetes/ssl/ca.crt
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: gce

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -73,6 +73,8 @@ metadata:
 spec:
   template:
     spec:
+      clusterConfiguration:
+        certificatesDir: /etc/kubernetes/ssl
       joinConfiguration:
         discovery: {}
         nodeRegistration:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1145

In our vintage product we are deploying certificates to `/etc/kubernetes/ssl` directory, so cert-exporter expects them to be there.

This PR aligns CAPI WCs with vintage WCs:
- Set certificates directory to `/etc/kubernetes/ssl` in KubeadmControlPanel and KubeadmConfigTemplate `clusterConfiguration`.
- Set CA certificate path to `/etc/kubernetes/ssl/ca.crt` in KubeadmControlPanel and KubeadmConfigTemplate `joinConfiguration`.