### PR TITLE
Handle incomplete machineDeployments array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure default values are used for `GCPMachineTemplate` if incomplete `machineDeployments` are provided
+
 ### Changed
 
 - Set certificates directory to `/etc/kubernetes/ssl` in KubeadmControlPanel and KubeadmConfigTemplate `clusterConfiguration`.

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -51,13 +51,13 @@ spec:
   template:
     spec:
       image: {{ include "vmImage" $global }}
-      instanceType: {{ .instanceType }}
-      rootDeviceSize: {{ .rootVolumeSizeGB }}
+      instanceType: {{ .instanceType | default "n2-standard-4" }}
+      rootDeviceSize: {{ .rootVolumeSizeGB | default 100 }}
       additionalDisks:
       - deviceType: pd-ssd
-        size: {{ .containerdVolumeSizeGB }}
+        size: {{ .containerdVolumeSizeGB | default 100 }}
       - deviceType: pd-ssd
-        size: {{ .kubeletVolumeSizeGB }}
+        size: {{ .kubeletVolumeSizeGB | default 100 }}
       {{- if .subnet }}
       subnet: {{ .subnet }}
       {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

If a `machineDeployments` array is provided where each item doesn't contain all keys then the default values from the values.yaml wont be used. This ensures that fallback values are always used if not found in the array.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create