### PR TITLE
Add localhost to certSANs of apiserver certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `localhost` and `127.0.0.1` to the certSANs of apiserver certificates.
+
 ## [0.20.1] - 2022-08-10
 
 ### Fixed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -21,6 +21,8 @@ spec:
         timeoutForControlPlane: 20m
         certSANs:
           - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+          - 127.0.0.1
+          - localhost
         extraArgs:
           audit-log-maxage: "30"
           audit-log-maxbackup: "30"


### PR DESCRIPTION
### What this PR does / why we need it

`chart-operator` fails in bootstrap mode because

```
x509: certificate is valid for 172.31.0.1, 10.164.0.6, 34.111.111.50, not 127.0.0.1
```

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create