### PR TITLE
Added hashSalt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `organization` a mandatory value to pass when installing the chart.
 - The `description` value is empty by default now.
 
+### Added
+
+- Optional `hashSalt` value to force recreation of immutable resources
+
 ## [0.22.0] - 2022-08-11
 
 ### Added

--- a/helm/cluster-gcp/templates/_bastion.tpl
+++ b/helm/cluster-gcp/templates/_bastion.tpl
@@ -28,13 +28,13 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" .Values.bastion }}
+          name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
       clusterName: {{ include "resource.default.name" $ }}
       failureDomain: {{ index .Values.gcp.failureDomains 0 }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPMachineTemplate
-        name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" .Values.bastion }}
+        name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
       version: {{ .Values.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -43,7 +43,7 @@ metadata:
   labels:
     cluster.x-k8s.io/role: bastion
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" .Values.bastion }}
+  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
   namespace: {{ .Release.Namespace }}
 spec:
   template:
@@ -63,7 +63,7 @@ metadata:
   labels:
     cluster.x-k8s.io/role: bastion
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" .Values.bastion }}
+  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -14,7 +14,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: GCPMachineTemplate
-      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" .Values.controlPlane }}
+      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
@@ -133,7 +133,7 @@ metadata:
   labels:
     cluster.x-k8s.io/role: control-plane
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" .Values.controlPlane }}
+  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:

--- a/helm/cluster-gcp/templates/_helpers.tpl
+++ b/helm/cluster-gcp/templates/_helpers.tpl
@@ -109,8 +109,17 @@ room for such suffix.
 {{ .Values.vmImageBase }}cluster-api-ubuntu-{{ .Values.ubuntuImageVersion }}-v{{ .Values.kubernetesVersion | replace "." "-" }}-gs
 {{- end -}}
 
+{{/*
+Hash function based on data provided
+Expects two arguments (as a `dict`) E.g.
+  {{ include "hash" (dict "data" . "global" $global) }}
+Where `data` is the data to has on and `global` is the top level scope.
+*/}}
 {{- define "hash" -}}
-{{- mustToJson . | toString | quote | sha1sum | trunc 8 }}
+{{- $data := mustToJson .data | toString  }}
+{{- $salt := "" }}
+{{- if .global.Values.hashSalt }}{{ $salt = .global.Values.hashSalt}}{{end}}
+{{- (printf "%s%s" $data $salt) | quote | sha1sum | trunc 8 }}
 {{- end -}}
 
 {{- define "kubeProxyFiles" }}

--- a/helm/cluster-gcp/templates/_helpers.tpl
+++ b/helm/cluster-gcp/templates/_helpers.tpl
@@ -113,7 +113,7 @@ room for such suffix.
 Hash function based on data provided
 Expects two arguments (as a `dict`) E.g.
   {{ include "hash" (dict "data" . "global" $global) }}
-Where `data` is the data to has on and `global` is the top level scope.
+Where `data` is the data to hash on and `global` is the top level scope.
 */}}
 {{- define "hash" -}}
 {{- $data := mustToJson .data | toString  }}

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -26,7 +26,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" . }}
+          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" . "global" $global) }}
       clusterName: {{ include "resource.default.name" $ }}
       {{- if (hasPrefix $.Values.gcp.region .failureDomain) }}
       failureDomain: {{ .failureDomain }}
@@ -36,7 +36,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPMachineTemplate
-        name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" . }}
+        name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" . "global" $global) }}
       version: {{ $.Values.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -45,7 +45,7 @@ metadata:
   labels:
     giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" . }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" . "global" $global) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
@@ -76,9 +76,9 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   labels:
-    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" . }}
+    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" . "global" $global) }}
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" . }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" . "global" $global) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -90,6 +90,9 @@
                 }
             }
         },
+        "hashSalt": {
+            "type": "string"
+        },
         "includeClusterResourceSet": {
             "type": "boolean"
         },

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -106,3 +106,7 @@ kubectlImage:
   registry: quay.io
   name: giantswarm/kubectl
   tag: 1.23.5
+
+# Used to force-recreate resources that use a hash suffix in their name.
+# To use, set this to a random string to trigger new hash values to be generated.
+hashSalt: ""


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

There are sometimes occasions when the hash suffix generated for immutable resources isn't updated when it needs to be. An example is when the template for that resource changes but not the values being used for that resource.

This update to the hash function allows for forcing a new hash to be generated by setting `.Values.hashSalt` to a random string.

/cc @erkanerol this might also be useful for CAPO / CAPVCD

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
