### PR TITLE
Correctly render SA scopes as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corectly render several scopes for the service accounts.
+
 ## [0.23.0] - 2022-08-11
 
 ### Changed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -153,5 +153,5 @@ spec:
       {{- end}}
       serviceAccounts:
         email: {{ .Values.controlPlane.serviceAccount.email }}
-        scopes: {{ .Values.controlPlane.serviceAccount.scopes }}
+        scopes: {{ .Values.controlPlane.serviceAccount.scopes | toYaml | nindent 8 }}
 {{- end -}}

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -56,7 +56,7 @@ spec:
       {{- if .serviceAccount }}
       serviceAccounts:
         email: {{ .serviceAccount.email }}
-        scopes: {{ .serviceAccount.scopes }}
+        scopes: {{ .serviceAccount.scopes | toYaml | nindent 8 }}
       {{- else }}
       serviceAccounts:
         email: "default"

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -61,6 +61,7 @@ machineDeployments:
     email: "default"
     scopes:
       - "https://www.googleapis.com/auth/compute"
+      - "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
   # subnet:
 - name: def01
   # description:
@@ -75,6 +76,7 @@ machineDeployments:
     email: "default"
     scopes:
       - "https://www.googleapis.com/auth/compute"
+      - "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
   # subnet:
 - name: def02
   # description:
@@ -89,6 +91,7 @@ machineDeployments:
     email: "default"
     scopes:
       - "https://www.googleapis.com/auth/compute"
+      - "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
   # subnet:
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"


### PR DESCRIPTION
### What this PR does / why we need it

The scopes were being rendered incorrectly like
```
serviceAccounts:
    email: capg-controller-manager@puc-f-gs-mgmt-sbx-f706.iam.gserviceaccount.com
    scopes:
    - https://www.googleapis.com/auth/compute https://www.googleapis.com/auth/ndev.clouddns.readwrite
```

But we want them as an array.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

