### PR TITLE
Improve hash function based on whole template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 helm/cluster-gcp/charts
 helm/rendered
+bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved hash function to hash based on whole `.Spec` rather than just provided values
+
 ## [0.26.1] - 2022-08-25
 
 ### Fixed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -4,7 +4,7 @@ CLUSTER ?= cluster-gcp-acceptance
 render: architect
 	mkdir -p $(shell pwd)/helm/rendered
 	cp -r $(shell pwd)/helm/cluster-gcp $(shell pwd)/helm/rendered/
-	helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog
+	helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog || echo
 	$(ARCHITECT) helm template --dir $(shell pwd)/helm/rendered/cluster-gcp
 	helm dependency build $(shell pwd)/helm/rendered/cluster-gcp
 

--- a/helm/cluster-gcp/templates/_bastion.tpl
+++ b/helm/cluster-gcp/templates/_bastion.tpl
@@ -1,3 +1,32 @@
+{{/*
+GCPMachineTemplates .Spec are immutable and cannot change.
+This function is used for both the `.Spec` value and as the data for the hash function.
+Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
+*/}}
+{{- define "bastion-gcpmachinetemplate-spec" -}}
+instanceType: {{ .Values.bastion.instanceType }}
+publicIP: true
+additionalNetworkTags:
+- {{ include "resource.default.name" $ }}-bastion
+image: {{ include "vmImage" $ }}
+subnet: {{ include "resource.default.name" $ }}-subnetwork
+{{- end }}
+
+{{/*
+KubeadmConfigTemplate .Spec are immutable and cannot change.
+This function is used for both the `.Spec` value and as the data for the hash function.
+Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
+*/}}
+{{- define "bastion-kubeadmconfigtemplate-spec" -}}
+preKubeadmCommands:
+{{- include "sshPostKubeadmCommands" $ | nindent 2 }}
+  - sleep infinity
+files:
+{{- include "sshFilesBastion" $ | nindent 2 }}
+users:
+{{- include "sshUsers" . | nindent 2 }}
+{{- end }}
+
 {{- define "bastion" }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -28,13 +57,13 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
+          name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-kubeadmconfigtemplate-spec" $) "global" .) }}
       clusterName: {{ include "resource.default.name" $ }}
       failureDomain: {{ index .Values.gcp.failureDomains 0 }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPMachineTemplate
-        name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
+        name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-gcpmachinetemplate-spec" $) "global" .) }}
       version: {{ .Values.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -43,17 +72,11 @@ metadata:
   labels:
     cluster.x-k8s.io/role: bastion
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
+  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-gcpmachinetemplate-spec" $) "global" .) }}
   namespace: {{ .Release.Namespace }}
 spec:
   template:
-    spec:
-      instanceType: {{ .Values.bastion.instanceType }}
-      publicIP: true
-      additionalNetworkTags:
-      - {{ include "resource.default.name" $ }}-bastion
-      image: {{ include "vmImage" $ }}
-      subnet: {{ include "resource.default.name" $ }}-subnetwork
+    spec: {{ include "bastion-gcpmachinetemplate-spec" $ | nindent 6 }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -61,16 +84,9 @@ metadata:
   labels:
     cluster.x-k8s.io/role: bastion
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" .Values.bastion "global" .) }}
+  name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-kubeadmconfigtemplate-spec" $) "global" .) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
-    spec:
-      preKubeadmCommands:
-      {{- include "sshPostKubeadmCommands" $ | nindent 6 }}
-      - sleep infinity
-      files:
-      {{- include "sshFilesBastion" $ | nindent 6 }}
-      users:
-      {{- include "sshUsers" . | nindent 6 }}
+    spec: {{ include "bastion-kubeadmconfigtemplate-spec" $ | nindent 6 }}
 {{- end -}}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -1,3 +1,26 @@
+{{/*
+GCPMachineTemplates .Spec are immutable and cannot change.
+This function is used for both the `.Spec` value and as the data for the hash function.
+Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
+*/}}
+{{- define "controlplane-gcpmachinetemplate-spec" -}}
+image: {{ include "vmImage" $ }}
+instanceType: {{ .Values.controlPlane.instanceType }}
+rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
+additionalDisks:
+- deviceType: pd-ssd
+  size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
+- deviceType: pd-ssd
+  size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
+- deviceType: pd-ssd
+  size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
+subnet: {{ include "resource.default.name" $ }}-subnetwork
+serviceAccounts:
+  email: {{ .Values.controlPlane.serviceAccount.email }}
+  scopes: {{ .Values.controlPlane.serviceAccount.scopes | toYaml | nindent 4 }}
+{{- end }}
+
+
 {{- define "control-plane" }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -14,7 +37,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: GCPMachineTemplate
-      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
+      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "controlplane-gcpmachinetemplate-spec" $) "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
@@ -134,23 +157,9 @@ metadata:
   labels:
     cluster.x-k8s.io/role: control-plane
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
+  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "controlplane-gcpmachinetemplate-spec" $) "global" .) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
-    spec:
-      image: {{ include "vmImage" $ }}
-      instanceType: {{ .Values.controlPlane.instanceType }}
-      rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
-      additionalDisks:
-      - deviceType: pd-ssd
-        size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
-      - deviceType: pd-ssd
-        size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
-      - deviceType: pd-ssd
-        size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
-      subnet: {{ include "resource.default.name" $ }}-subnetwork
-      serviceAccounts:
-        email: {{ .Values.controlPlane.serviceAccount.email }}
-        scopes: {{ .Values.controlPlane.serviceAccount.scopes | toYaml | nindent 8 }}
+    spec: {{ include "controlplane-gcpmachinetemplate-spec" $ | nindent 6 }}
 {{- end -}}

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -122,7 +122,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
-    spec:{{ include "machinedeployment-kubeadmconfigtemplate-spec" $thisVal | nindent 6 }}
+    spec: {{ include "machinedeployment-kubeadmconfigtemplate-spec" $thisVal | nindent 6 }}
 ---
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Updates the usage of the `hash` function to pass in the whole template its related to, rather than just the values. 

This should hopefully avoid all instances where Helm attempts to update immutable values in-place rather than recreating.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
