### PR TITLE
Set only routeTableId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set only routeTableId for the GCPCluster subnetworks
+
 ## [0.27.0] - 2022-09-20
 
 ### Added

--- a/helm/cluster-gcp/templates/_gcp_cluster.tpl
+++ b/helm/cluster-gcp/templates/_gcp_cluster.tpl
@@ -18,12 +18,11 @@ spec:
       cidrBlock: {{ .Values.network.nodeSubnetCidr }}
       region: {{ $.Values.gcp.region }}
       routeTableId: false
-      enableFlowLogs: false
     {{- if .Values.network.proxySubnetCidr }}
     - name: {{ include "resource.default.name" $ }}-subnetwork-proxy
       cidrBlock: {{ .Values.network.proxySubnetCidr }}
       region: {{ $.Values.gcp.region }}
-      enableFlowLogs: false
+      routeTableId: false
       purpose: REGIONAL_MANAGED_PROXY
     {{- end }}
   region: {{ .Values.gcp.region }}


### PR DESCRIPTION
The rename from routeTableId to enableFlowLogs hasn't been released upstream yet. The field has to be set because in the go structs it's of type `*bool` and does not have the `omitempty` json annotation

Co-authored-by: Mario Nitchev <mario@giantswarm.io>

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
