### PR TITLE
Make kubeadm skip kube-proxy deployment as we will use cilium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `kubeadm` skip the phase where it installs `kube-proxy` as we will use `cilium` as a replacement.
+
 ## [0.28.0] - 2022-09-29
 
 ### Changed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -124,6 +124,8 @@ spec:
     {{- include "kubeProxyFiles" . | nindent 4 }}
     {{- include "kubernetesFiles" . | nindent 4 }}
     initConfiguration:
+      skipPhases:
+      - addon/kube-proxy
       localAPIEndpoint:
         advertiseAddress: ""
         bindPort: 0


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/1456
Make kubeadm skip kube-proxy deployment as we will use cilium. It requires CAPI >= `v1.2.0`.

### Checklist

- [X] Update changelog in CHANGELOG.md.

