### PR TITLE
Ubuntu 22.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated to Kubernetes 1.22.15
+- Updated to using Ubuntu 22.04 as base OS
+
 ## [0.29.0] - 2022-10-10
 
 ### Changed
@@ -39,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix helm upgrade failing with a map cycle while using the default values. 
+- Fix helm upgrade failing with a map cycle while using the default values.
 
 ### Changed
 

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -2,8 +2,8 @@ clusterName: "test"  # Name of cluster. Used as base name for all cluster resour
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
-kubernetesVersion: 1.22.10
-ubuntuImageVersion: "2004"
+kubernetesVersion: 1.22.15
+ubuntuImageVersion: "2204"
 
 vmImageBase: "https://www.googleapis.com/compute/v1/projects/giantswarm-vm-images/global/images/"
 


### PR DESCRIPTION
:warning: Blocked by https://github.com/giantswarm/cilium-app/pull/44

### What this PR does / why we need it

Towards: https://github.com/giantswarm/roadmap/issues/1324 

* Updates to latest patch release of Kubernetes 1.22
* Switches the base OS to use Ubuntu 22.04

Waiting on image being ready...

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
