### PR TITLE
allow-tcp-forward-for-bastion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable tcp forwarding for sshd on bastion.
+
 ## [0.29.0] - 2022-10-10
 
 ### Changed

--- a/helm/cluster-gcp/files/etc/ssh/sshd_config_bastion
+++ b/helm/cluster-gcp/files/etc/ssh/sshd_config_bastion
@@ -11,5 +11,5 @@ PasswordAuthentication no
 TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
 MaxAuthTries 5
 LoginGraceTime 60
-AllowTcpForwarding no
+AllowTcpForwarding yes
 AllowAgentForwarding yes


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1380

necessary for nested ssh proxy commands to forwards STDIN and STDOUT