### PR TITLE
Skip kubeadm coredns installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `kubeadm` skip the phase where it installs `coredns` as it will be installed by as a default app.
+
 ## [0.30.1] - 2022-10-19
 
 ### Changed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -126,6 +126,7 @@ spec:
     initConfiguration:
       skipPhases:
       - addon/kube-proxy
+      - addon/coredns
       localAPIEndpoint:
         advertiseAddress: ""
         bindPort: 0

--- a/helm/cluster-gcp/templates/list.yaml
+++ b/helm/cluster-gcp/templates/list.yaml
@@ -1,6 +1,4 @@
 ---
-{{- include "coredns" . }}
----
 {{- include "psps" . }}
 ---
 {{- include "cluster" . }}

--- a/scripts/pod-test.yaml
+++ b/scripts/pod-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: coredns-adapter-test-pod
+  name: cluster-shared-test-pod
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16,7 +16,7 @@ subjects:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: coredns-adapter-test-pod
+  name: cluster-shared-test-pod
   namespace: default
 spec:
   serviceAccountName: default
@@ -42,5 +42,5 @@ spec:
   volumes:
     - name: configmap-manifests
       configMap:
-        name: test-coredns
+        name: test-psps
   restartPolicy: Never

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,17 +8,12 @@ kubectl apply -f "${SCRIPT_DIR}/pod-test.yaml"
 # We need to wait until the job is actually created, before we can 'kubectl wait' for it.
 sleep 15
 
-# Check that everything is as expected.
-kubectl -n kube-system wait --timeout 100s --for condition=complete job/coredns-adopter
-kubectl -n kube-system wait --timeout 1s --for condition=available deploy/coredns-workers
-
-if [[ ! $(kubectl get svc -n kube-system coredns) ]]; then
-  echo "Missing coredns Service"
+if [[ ! $(kubectl get psp privileged) ]]; then
+  echo "Missing privileged PodSecurityPolicy"
   exit 1
 fi
-
-if [[ ! $(kubectl get job -n kube-system coredns-adopter -o json | jq '.status.succeeded') ]]; then
-  echo "coredns-adopter job is not marked as succeeded"
+if [[ ! $(kubectl get psp restricted) ]]; then
+  echo "Missing restricted PodSecurityPolicy"
   exit 1
 fi
 


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/24276

With these changes, we don't create the job that updates `coredns` manifests to adopt it as an app. Instead, we tell `kubeadm` not to deploy `coredns`, and later on, the app platform will deploy `coredns` as a default app.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
