### PR TITLE
Support setting custom node taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support setting node taints using `customNodeTaints`
+
 ## [0.32.1] - 2022-11-03
 
 ### Fixed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -138,12 +138,32 @@ spec:
           node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
           v: "2"
         name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
+        {{- if .Values.controlPlane.customNodeTaints }}
+        {{- if (gt (len .Values.controlPlane.customNodeTaints) 0) }}
+        taints:
+        {{- range .Values.controlPlane.customNodeTaints }}
+        - key: {{ .key | quote }}
+          value: {{ .value | quote }}
+          effect: {{ .effect | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     joinConfiguration:
       discovery: {}
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: gce
         name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
+        {{- if .Values.controlPlane.customNodeTaints }}
+        {{- if (gt (len .Values.controlPlane.customNodeTaints) 0) }}
+        taints:
+        {{- range .Values.controlPlane.customNodeTaints }}
+        - key: {{ .key | quote }}
+          value: {{ .value | quote }}
+          effect: {{ .effect | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     preKubeadmCommands:
     - /bin/bash /opt/init-disks.sh
     - /bin/bash /etc/gs-kube-proxy-patch.sh

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -43,6 +43,16 @@ joinConfiguration:
       node-labels: role=worker,giantswarm.io/machine-deployment={{ .name }}{{ if .customNodeLabels }},{{- join "," .customNodeLabels }}{{ end }}
       v: "2"
     name: '{{ `{{ ds.meta_data.local_hostname.split(".")[0] }}` }}'
+    {{- if .customNodeTaints }}
+    {{- if (gt (len .customNodeTaints) 0) }}
+    taints:
+    {{- range .customNodeTaints }}
+    - key: {{ .key | quote }}
+      value: {{ .value | quote }}
+      effect: {{ .effect | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 files:
 {{ .sshFiles }}
 {{ .diskFiles }}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -37,6 +37,9 @@
                 "containerdVolumeSizeGB": {
                     "type": "integer"
                 },
+                "customNodeTaints": {
+                    "type": "array"
+                },
                 "etcd": {
                     "type": "object",
                     "properties": {
@@ -125,6 +128,9 @@
                         "type": "integer"
                     },
                     "customNodeLabels": {
+                        "type": "array"
+                    },
+                    "customNodeTaints": {
                         "type": "array"
                     },
                     "failureDomain": {

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -69,6 +69,10 @@ machineDeployments:
   containerdVolumeSizeGB: 100
   kubeletVolumeSizeGB: 100
   customNodeLabels: []
+  customNodeTaints: []
+    # - key: ""
+    #   value: ""
+    #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
   serviceAccount:  # A service account used by workloads using google SDK on this nodepool.
     email: "default"
     scopes:
@@ -83,6 +87,10 @@ machineDeployments:
   containerdVolumeSizeGB: 100
   kubeletVolumeSizeGB: 100
   customNodeLabels: []
+  customNodeTaints: []
+    # - key: ""
+    #   value: ""
+    #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
   serviceAccount:  # A service account used by workloads using google SDK on this nodepool.
     email: "default"
     scopes:
@@ -97,6 +105,10 @@ machineDeployments:
   containerdVolumeSizeGB: 100
   kubeletVolumeSizeGB: 100
   customNodeLabels: []
+  customNodeTaints: []
+    # - key: ""
+    #   value: ""
+    #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
   serviceAccount:  # A service account used by workloads using google SDK on this nodepool.
     email: "default"
     scopes:


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Fixes https://github.com/giantswarm/roadmap/issues/1587

Supports setting custom taints on both worker nodes and control plane nodes.

Note: does not allow for removing of default taints! (by design)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
