### PR TITLE
Disk Type for all volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump external-dns to latest release
+- Allow to specify the disk type for all volumes (root, etcd, kubelet, containerd) in the machine templates
 
 ## [0.33.1] - 2022-11-08
 

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -10,7 +10,7 @@ rootDeviceSize: {{ .Values.controlPlane.rootVolume.sizeGB | default 100 }}
 rootDeviceType: {{ .Values.controlPlane.rootVolume.diskType | default "pd-ssd" }}
 additionalDisks:
 - deviceType: "local-ssd"
-  size: {{ .Values.controlPlane.etcdVolume.sizeGB | default 100 }}
+  size: 375  # 375 is the minimum size for a local-ssd
 - deviceType: {{ .Values.controlPlane.containerdVolume.diskType | default "pd-ssd" }}
   size: {{ .Values.controlPlane.containerdVolume.sizeGB | default 100 }}
 - deviceType: {{ .Values.controlPlane.kubeletVolume.diskType | default "pd-ssd" }}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -9,7 +9,7 @@ instanceType: {{ .Values.controlPlane.instanceType }}
 rootDeviceSize: {{ .Values.controlPlane.rootVolume.sizeGB | default 100 }}
 rootDeviceType: {{ .Values.controlPlane.rootVolume.diskType | default "pd-ssd" }}
 additionalDisks:
-- deviceType: {{ .Values.controlPlane.etcdVolume.diskType | default "local-ssd" }}
+- deviceType: "local-ssd"
   size: {{ .Values.controlPlane.etcdVolume.sizeGB | default 100 }}
 - deviceType: {{ .Values.controlPlane.containerdVolume.diskType | default "pd-ssd" }}
   size: {{ .Values.controlPlane.containerdVolume.sizeGB | default 100 }}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -6,14 +6,15 @@ Any changes to this will trigger the resource to be recreated rather than attemp
 {{- define "controlplane-gcpmachinetemplate-spec" -}}
 image: {{ include "vmImage" $ }}
 instanceType: {{ .Values.controlPlane.instanceType }}
-rootDeviceSize: {{ .Values.controlPlane.rootVolumeSizeGB }}
+rootDeviceSize: {{ .Values.controlPlane.rootVolume.sizeGB | default 100 }}
+rootDeviceType: {{ .Values.controlPlane.rootVolume.diskType | default "pd-ssd" }}
 additionalDisks:
-- deviceType: pd-ssd
-  size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
-- deviceType: pd-ssd
-  size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
-- deviceType: pd-ssd
-  size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
+- deviceType: {{ .Values.controlPlane.etcdVolume.diskType default "local-ssd" }}
+  size: {{ .Values.controlPlane.etcdVolume.sizeGB | default 100 }}
+- deviceType: {{ .Values.controlPlane.containerdVolume.diskType default "pd-ssd" }}
+  size: {{ .Values.controlPlane.containerdVolume.sizeGB | default 100 }}
+- deviceType: {{ .Values.controlPlane.kubeletVolume.diskType default "pd-ssd" }}
+  size: {{ .Values.controlPlane.kubeletVolume.sizeGB | default 100 }}
 subnet: {{ include "resource.default.name" $ }}-subnetwork
 serviceAccounts:
   email: {{ .Values.controlPlane.serviceAccount.email }}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -9,7 +9,7 @@ instanceType: {{ .Values.controlPlane.instanceType }}
 rootDeviceSize: {{ .Values.controlPlane.rootVolume.sizeGB | default 100 }}
 rootDeviceType: {{ .Values.controlPlane.rootVolume.diskType | default "pd-ssd" }}
 additionalDisks:
-- deviceType: {{ .Values.controlPlane.etcdVolume.diskType default "local-ssd" }}
+- deviceType: {{ .Values.controlPlane.etcdVolume.diskType | default "local-ssd" }}
   size: {{ .Values.controlPlane.etcdVolume.sizeGB | default 100 }}
 - deviceType: {{ .Values.controlPlane.containerdVolume.diskType default "pd-ssd" }}
   size: {{ .Values.controlPlane.containerdVolume.sizeGB | default 100 }}

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -11,9 +11,9 @@ rootDeviceType: {{ .Values.controlPlane.rootVolume.diskType | default "pd-ssd" }
 additionalDisks:
 - deviceType: {{ .Values.controlPlane.etcdVolume.diskType | default "local-ssd" }}
   size: {{ .Values.controlPlane.etcdVolume.sizeGB | default 100 }}
-- deviceType: {{ .Values.controlPlane.containerdVolume.diskType default "pd-ssd" }}
+- deviceType: {{ .Values.controlPlane.containerdVolume.diskType | default "pd-ssd" }}
   size: {{ .Values.controlPlane.containerdVolume.sizeGB | default 100 }}
-- deviceType: {{ .Values.controlPlane.kubeletVolume.diskType default "pd-ssd" }}
+- deviceType: {{ .Values.controlPlane.kubeletVolume.diskType | default "pd-ssd" }}
   size: {{ .Values.controlPlane.kubeletVolume.sizeGB | default 100 }}
 subnet: {{ include "resource.default.name" $ }}-subnetwork
 serviceAccounts:

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -6,7 +6,8 @@ Any changes to this will trigger the resource to be recreated rather than attemp
 {{- define "machinedeployment-gcpmachinetemplate-spec" -}}
 image: {{ .vmImage }}
 instanceType: {{ .instanceType | default "n2-standard-4" }}
-rootDeviceSize: {{ .rootVolumeSizeGB | default 100 }}
+rootDeviceSize: {{ .rootVolume.sizeGB | default 100 }}
+rootDeviceType: {{ .rootVolume.diskType | default "pd-ssd" }}
 {{- if .serviceAccount }}
 serviceAccounts:
   email: {{ .serviceAccount.email }}
@@ -18,10 +19,10 @@ serviceAccounts:
   - "https://www.googleapis.com/auth/compute"
 {{- end }}
 additionalDisks:
-- deviceType: pd-ssd
-  size: {{ .containerdVolumeSizeGB | default 100 }}
-- deviceType: pd-ssd
-  size: {{ .kubeletVolumeSizeGB | default 100 }}
+- deviceType: {{ .containerdVolume.diskType | default "pd-ssd" }}
+  size: {{ .containerdVolume.sizeGB | default 100 }}
+- deviceType: {{ .kubeletVolume.diskType | default "pd-ssd" }}
+  size: {{ .kubeletVolume.sizeGB | default 100 }}
 subnet: {{ .resourceDefaultName }}-subnetwork
 {{- end }}
 

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -59,17 +59,6 @@
                         }
                     }
                 },
-                "etcdVolume": {
-                    "type": "object",
-                    "properties": {
-                        "sizeGB": {
-                            "type": "integer"
-                        },
-                        "diskType": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "instanceType": {
                     "type": "string"
                 },

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -34,8 +34,16 @@
                 "apiAllowlistSubnets": {
                     "type": "string"
                 },
-                "containerdVolumeSizeGB": {
-                    "type": "integer"
+                "containerdVolume": {
+                    "type": "object",
+                    "properties": {
+                        "sizeGB": {
+                            "type": "integer"
+                        },
+                        "diskType": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "customNodeTaints": {
                     "type": "array"
@@ -51,17 +59,41 @@
                         }
                     }
                 },
-                "etcdVolumeSizeGB": {
-                    "type": "integer"
+                "etcdVolume": {
+                    "type": "object",
+                    "properties": {
+                        "sizeGB": {
+                            "type": "integer"
+                        },
+                        "diskType": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "instanceType": {
                     "type": "string"
                 },
-                "kubeletVolumeSizeGB": {
-                    "type": "integer"
+                "kubeletVolume": {
+                    "type": "object",
+                    "properties": {
+                        "sizeGB": {
+                            "type": "integer"
+                        },
+                        "diskType": {
+                            "type": "string"
+                        }
+                    }
                 },
-                "rootVolumeSizeGB": {
-                    "type": "integer"
+                "rootVolume": {
+                    "type": "object",
+                    "properties": {
+                        "sizeGB": {
+                            "type": "integer"
+                        },
+                        "diskType": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -124,8 +156,16 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "containerdVolumeSizeGB": {
-                        "type": "integer"
+                    "containerdVolume": {
+                        "type": "object",
+                        "properties": {
+                            "sizeGB": {
+                                "type": "integer"
+                            },
+                            "diskType": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "customNodeLabels": {
                         "type": "array"
@@ -139,8 +179,16 @@
                     "instanceType": {
                         "type": "string"
                     },
-                    "kubeletVolumeSizeGB": {
-                        "type": "integer"
+                    "kubeletVolume": {
+                        "type": "object",
+                        "properties": {
+                            "sizeGB": {
+                                "type": "integer"
+                            },
+                            "diskType": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "name": {
                         "type": "string"
@@ -148,8 +196,16 @@
                     "replicas": {
                         "type": "integer"
                     },
-                    "rootVolumeSizeGB": {
-                        "type": "integer"
+                    "rootVolume": {
+                        "type": "object",
+                        "properties": {
+                            "sizeGB": {
+                                "type": "integer"
+                            },
+                            "diskType": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "serviceAccount": {
                         "type": "object",

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -48,9 +48,6 @@ controlPlane:
   rootVolume:
     sizeGB: 100
     diskType: "pd-ssd"  # Defaults to "pd-standard", the other only supported type is "pd-ssd"
-  etcdVolume:
-    sizeGB: 100
-    diskType: "local-ssd"  # Override to allow etcd more IO operations
   containerdVolume:
     sizeGB: 100
     diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -47,18 +47,18 @@ controlPlane:
   instanceType: n2-standard-4
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
   etcdVolume:
     sizeGB: 100
-    diskType: "local-ssd" # Override to allow etcd more IO operations
+    diskType: "local-ssd"  # Override to allow etcd more IO operations
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   serviceAccount:
-    email: "default"  # A service account used by the control-plane to set up LoadBalancer Services
+    email: "default"   # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
     - "https://www.googleapis.com/auth/compute"
   etcd:
@@ -75,13 +75,13 @@ machineDeployments:
   replicas: 1
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""
@@ -97,9 +97,15 @@ machineDeployments:
   failureDomain: europe-west3-b
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 100
-  containerdVolumeSizeGB: 100
-  kubeletVolumeSizeGB: 100
+  rootVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+  containerdVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+  kubeletVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""
@@ -115,9 +121,15 @@ machineDeployments:
   failureDomain: europe-west3-c
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 100
-  containerdVolumeSizeGB: 100
-  kubeletVolumeSizeGB: 100
+  rootVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+  containerdVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+  kubeletVolume:
+    sizeGB: 100
+    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -47,16 +47,16 @@ controlPlane:
   instanceType: n2-standard-4
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # Defaults to "pd-standard", the other only supported type is "pd-ssd"
   etcdVolume:
     sizeGB: 100
     diskType: "local-ssd"  # Override to allow etcd more IO operations
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   serviceAccount:
     email: "default"   # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
@@ -75,13 +75,13 @@ machineDeployments:
   replicas: 1
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # Defaults to "pd-standard", the other only supported type is "pd-ssd"
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""
@@ -99,13 +99,13 @@ machineDeployments:
   replicas: 1
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # Defaults to "pd-standard", the other only supported type is "pd-ssd"
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""
@@ -123,13 +123,13 @@ machineDeployments:
   replicas: 1
   rootVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+    diskType: "pd-ssd"  # Defaults to "pd-standard", the other only supported type is "pd-ssd"
   containerdVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   kubeletVolume:
     sizeGB: 100
-    diskType: "pd-ssd"  # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+    diskType: "pd-ssd"  # Defaults to "pd-standard", other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -45,10 +45,18 @@ bastion:
 controlPlane:
   apiAllowlistSubnets: ""  # A comma separated list of cidrs that will have access to the kubernetes API.
   instanceType: n2-standard-4
-  rootVolumeSizeGB: 100
-  etcdVolumeSizeGB: 100
-  containerdVolumeSizeGB: 100
-  kubeletVolumeSizeGB: 100
+  rootVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+  etcdVolume:
+    sizeGB: 100
+    diskType: "local-ssd" # Override to allow etcd more IO operations
+  containerdVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+  kubeletVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   serviceAccount:
     email: "default"  # A service account used by the control-plane to set up LoadBalancer Services
     scopes:
@@ -65,9 +73,15 @@ machineDeployments:
   failureDomain: europe-west3-a
   instanceType: n2-standard-4
   replicas: 1
-  rootVolumeSizeGB: 100
-  containerdVolumeSizeGB: 100
-  kubeletVolumeSizeGB: 100
+  rootVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, the other only supported type is "pd-ssd"
+  containerdVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
+  kubeletVolume:
+    sizeGB: 100
+    diskType: "pd-ssd" # "pd-standard" is the default one, other options are: ["pd-ssd"|"local-ssd"]
   customNodeLabels: []
   customNodeTaints: []
     # - key: ""


### PR DESCRIPTION
### What this PR does / why we need it
This PR allows to configure the `diskType` for all volumes (root, etcd, kubelet, containerd)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
