### PR TITLE
Make 'baseDomain' a required value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump external-dns to latest release
+- Make `baseDomain` a required value.
 
 ## [0.33.1] - 2022-11-08
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -12,7 +12,7 @@ render: architect
 # Instead we template the chart and apply ignoring errors.
 .PHONY: render
 deploy-rendered-chart: render
-	helm upgrade --install test $(shell pwd)/helm/rendered/cluster-gcp --set gcp.project="test-project" --set organization="test"
+	helm upgrade --install test $(shell pwd)/helm/rendered/cluster-gcp --set gcp.project="test-project" --set organization="test" --set baseDomain="example.com"
 
 .PHONY: create-acceptance-cluster
 create-acceptance-cluster: kind

--- a/helm/cluster-gcp/ci/ci-values.yaml
+++ b/helm/cluster-gcp/ci/ci-values.yaml
@@ -1,3 +1,4 @@
 organization: "test"
 gcp:
   project: "test-project"
+baseDomain: example.com

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -43,7 +43,7 @@ spec:
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:
-          - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+          - "api.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
           - 127.0.0.1
           - localhost
         extraArgs:


### PR DESCRIPTION
### What this PR does / why we need it

There was a problem setting the `baseDomain` last week, and clusters kept being created relying on the default `baseDomain`, which was set to example.com. This made that the clusters were not being created successfully.

Instead, this value should be always be passed and fail if that's not the case.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
