### PR TITLE
Specify `customNodeTaints` items schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `customNodeTain` items schema.
+
 ### Changed
 
 - Make `baseDomain` a required value.

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -38,7 +38,10 @@
                     "type": "integer"
                 },
                 "customNodeTaints": {
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/nodeTaint"
+                    }
                 },
                 "etcd": {
                     "type": "object",
@@ -131,7 +134,10 @@
                         "type": "array"
                     },
                     "customNodeTaints": {
-                        "type": "array"
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/nodeTaint"
+                        }
                     },
                     "failureDomain": {
                         "type": "string"
@@ -219,6 +225,32 @@
         },
         "vmImageBase": {
             "type": "string"
+        }
+    },
+    "$defs": {
+        "nodeTaint": {
+            "type": "object",
+            "properties": {
+                "effect": {
+                    "type": "string",
+                    "enum": [
+                        "NoSchedule",
+                        "PreferNoSchedule",
+                        "NoExecute"
+                    ]
+                },
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "effect",
+                "key",
+                "value"
+            ]
         }
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it

Adds `items` schema for `.customNodeTaints`.

This is required for proper validation and generating a data entry form for this app (towards https://github.com/giantswarm/roadmap/issues/1181)

As there are two arrays for custom node taints, the item schema is defined in the `$defs` section and referenced multiple times.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
