### PR TITLE
Specify items schema for customNodeLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `customNodeTain` items schema.
+- Add `customNodeLabels` items schema.
 
 ### Changed
 

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -131,7 +131,10 @@
                         "type": "integer"
                     },
                     "customNodeLabels": {
-                        "type": "array"
+                        "type": "array",
+                        "items": {
+                            "$ref": "https://schema.giantswarm.io/labelvalue/v0.0.1"
+                        }
                     },
                     "customNodeTaints": {
                         "type": "array",


### PR DESCRIPTION
### What this PR does / why we need it

Adds the missing schema for items of the `customNodeLabels` array.

Depends on https://github.com/giantswarm/schema/pull/2

Towards https://github.com/giantswarm/roadmap/issues/1181

### Checklist

- [x] Update changelog in CHANGELOG.md.

