### PR TITLE
Add servicePriority cluster property

### DIFF
--- a/helm/cluster-gcp/ci/ci-values.yaml
+++ b/helm/cluster-gcp/ci/ci-values.yaml
@@ -2,3 +2,4 @@ organization: "test"
 gcp:
   project: "test-project"
 baseDomain: example.com
+servicePriority: lowest

--- a/helm/cluster-gcp/templates/_cluster.tpl
+++ b/helm/cluster-gcp/templates/_cluster.tpl
@@ -6,6 +6,9 @@ metadata:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
+    {{- if ne .Values.servicePriority "" }}
+    giantswarm.io/service-priority: {{ .Values.servicePriority }}
+    {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster-gcp/values.schema.json
+++ b/helm/cluster-gcp/values.schema.json
@@ -28,6 +28,18 @@
         "clusterName": {
             "type": "string"
         },
+        "servicePriority": {
+            "type": "string",
+            "title": "Service priority",
+            "description": "The relative importance of this cluster.",
+            "default": "highest",
+            "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+            "enum": [
+                "highest",
+                "medium",
+                "lowest"
+            ]
+        },
         "controlPlane": {
             "type": "object",
             "properties": {

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -2,7 +2,7 @@ clusterName: "test"  # Name of cluster. Used as base name for all cluster resour
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
-servicePriority: ""
+servicePriority: "highest"
 kubernetesVersion: 1.23.13
 ubuntuImageVersion: "2204"
 

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -2,6 +2,7 @@ clusterName: "test"  # Name of cluster. Used as base name for all cluster resour
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
+servicePriority: ""
 kubernetesVersion: 1.23.13
 ubuntuImageVersion: "2204"
 


### PR DESCRIPTION
### What this PR does / why we need it

Adds the option to specify the service priority label, as defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
