### PR TITLE
Rollback kubernetes version to 1.23.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make `baseDomain` a required value.
-- Bump kubernetes version to v1.23.16
 
 ## [0.33.1] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rollback kubernetes version, as upgrade is broken.
+
 ## [0.34.0] - 2023-01-27
 
 ### Added

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -2,7 +2,7 @@ clusterName: "test"  # Name of cluster. Used as base name for all cluster resour
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
-kubernetesVersion: 1.23.16
+kubernetesVersion: 1.23.13
 ubuntuImageVersion: "2204"
 
 vmImageBase: "https://www.googleapis.com/compute/v1/projects/giantswarm-vm-images/global/images/"


### PR DESCRIPTION
### What this PR does / why we need it

Rollback kubernetes version to 1.23.13 as upgrade path is broken.

https://github.com/kubernetes-sigs/cluster-api/issues/7768
https://github.com/kubernetes-sigs/cluster-api/issues/7833

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
