### PR TITLE
Bump kubernetes version and use Giantswarm image repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rollback kubernetes version, as upgrade is broken.
+- Use Giantswarm repository for Kubernetes images.
+- Bump Kubernetes to v1.23.16
 
 ## [0.34.0] - 2023-01-27
 

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -40,6 +40,8 @@ spec:
       name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "controlplane-gcpmachinetemplate-spec" $) "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
+      # Avoid accessibility issues (e.g. on private clusters) and potential future rate limits for the default `registry.k8s.io`
+      imageRepository: docker.io/giantswarm
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:

--- a/helm/cluster-gcp/values.yaml
+++ b/helm/cluster-gcp/values.yaml
@@ -2,7 +2,7 @@ clusterName: "test"  # Name of cluster. Used as base name for all cluster resour
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
-kubernetesVersion: 1.23.13
+kubernetesVersion: 1.23.16
 ubuntuImageVersion: "2204"
 
 vmImageBase: "https://www.googleapis.com/compute/v1/projects/giantswarm-vm-images/global/images/"


### PR DESCRIPTION
### What this PR does / why we need it

In order to update kubernetes, we need to change imageRepository as coredns image path is not calculated correctly.

* https://github.com/kubernetes-sigs/cluster-api/issues/7768
* https://github.com/kubernetes-sigs/cluster-api/issues/7833

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
