### PR TITLE
Set right permissions to /var/lib/kubelet for node-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `/var/lib/kubelet` permissions to `0750` to fix `node-exporter` issue.
+
 ## [0.35.0] - 2023-01-30
 
 ### Changed

--- a/helm/cluster-gcp/templates/_control_plane.tpl
+++ b/helm/cluster-gcp/templates/_control_plane.tpl
@@ -166,6 +166,7 @@ spec:
         {{- end }}
         {{- end }}
     preKubeadmCommands:
+    {{- include "prepare-varLibKubelet-Dir" . | nindent 4 }}
     - /bin/bash /opt/init-disks.sh
     - /bin/bash /etc/gs-kube-proxy-patch.sh
     postKubeadmCommands:

--- a/helm/cluster-gcp/templates/_helpers.tpl
+++ b/helm/cluster-gcp/templates/_helpers.tpl
@@ -116,6 +116,10 @@ subnetwork-name={{ include "resource.default.name" $ }}-subnetwork
 {{ .Values.vmImageBase }}cluster-api-ubuntu-{{ .Values.ubuntuImageVersion }}-v{{ .Values.kubernetesVersion | replace "." "-" }}-gs
 {{- end -}}
 
+{{- define "prepare-varLibKubelet-Dir" -}}
+- /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
+{{- end -}}
+
 {{/*
 Hash function based on data provided
 Expects two arguments (as a `dict`) E.g.

--- a/helm/cluster-gcp/templates/_machine_deployments.tpl
+++ b/helm/cluster-gcp/templates/_machine_deployments.tpl
@@ -57,6 +57,7 @@ files:
 {{ .sshFiles }}
 {{ .diskFiles }}
 preKubeadmCommands:
+{{- include "prepare-varLibKubelet-Dir" . | nindent 0 }}
 - /bin/bash /opt/init-disks.sh
 postKubeadmCommands:
 {{ .sshPostKubeadmCommands }}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/25275

Without these permissions, `node-exporter` fails to retrieve info from the filesystem. Related: https://github.com/giantswarm/cluster-azure/pull/41

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
