### PR TITLE
Update cluster-shared dependency to 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set `/var/lib/kubelet` permissions to `0750` to fix `node-exporter` issue.
+- Update `cluster-shared` dependency to `0.6.5`
 
 ## [0.35.0] - 2023-01-30
 

--- a/helm/cluster-gcp/Chart.lock
+++ b/helm/cluster-gcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.6.4
-digest: sha256:8df8c11fb4553caa08324abbbd9d119422049e26de209c747c6a0f91b1343783
-generated: "2022-11-08T10:01:14.231507Z"
+  version: 0.6.5
+digest: sha256:954be7fbf2365fca44d3a84aaf0e5272d9022f3146d4d9ead38f8e1e275a92f8
+generated: "2023-06-01T15:53:55.221189626+02:00"

--- a/helm/cluster-gcp/Chart.yaml
+++ b/helm/cluster-gcp/Chart.yaml
@@ -11,6 +11,6 @@ restrictions:
     - gcp
 dependencies:
 - name: cluster-shared
-  version: "0.6.4"
+  version: "0.6.5"
   repository: "https://giantswarm.github.io/cluster-catalog"
 icon: https://s.giantswarm.io/app-icons/gcp/1/light.svg


### PR DESCRIPTION
### What this PR does / why we need it

Update `cluster-shared` dependency to `0.6.5`

* Adds seccomp annotation to restricted psp

Towards https://github.com/giantswarm/giantswarm/issues/27124

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
